### PR TITLE
Add annotation and documentation types

### DIFF
--- a/xml_schema_derive/src/xsd/annotation.rs
+++ b/xml_schema_derive/src/xsd/annotation.rs
@@ -1,0 +1,45 @@
+use crate::xsd::{attribute::Attribute, XsdContext};
+use log::info;
+use proc_macro2::TokenStream;
+use std::io::prelude::*;
+use yaserde::YaDeserialize;
+
+#[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
+#[yaserde(
+    rename = "annotation"
+    prefix = "xs",
+    namespace = "xs: http://www.w3.org/2001/XMLSchema"
+  )]
+pub struct Annotation {
+  #[yaserde(attribute)]
+  pub id: Option<String>,
+  #[yaserde(rename = "attribute")]
+  pub attributes: Vec<Attribute>,
+  #[yaserde(
+      rename = "documentation"
+      prefix = "xs",
+      namespace = "xs: http://www.w3.org/2001/XMLSchema"
+    )]
+  pub documentation: Vec<String>,
+}
+
+impl Annotation {
+  pub fn get_implementation(
+    &self,
+    namespace_definition: &TokenStream,
+    prefix: &Option<String>,
+    context: &XsdContext,
+  ) -> TokenStream {
+    info!("Generate annotation");
+
+    let documentation = self.documentation.iter().map(|documentation| {
+      quote! {
+        #[doc = #documentation]
+      }
+    });
+
+    quote! {
+      #(#documentation)*
+    }
+  }
+}

--- a/xml_schema_derive/src/xsd/attribute.rs
+++ b/xml_schema_derive/src/xsd/attribute.rs
@@ -55,16 +55,11 @@ impl Attribute {
 
     let field_name = Ident::new(&name, Span::call_site());
 
-    let rust_type = 
-      match (self.reference.as_ref(), self.kind.as_ref()) {
-        (None, Some(kind)) => {
-          RustTypesMapping::get(context, &kind)
-        }
-        (Some(reference), None) => {
-          RustTypesMapping::get(context, &reference)
-        }
-        (_, _) => unimplemented!()
-      };
+    let rust_type = match (self.reference.as_ref(), self.kind.as_ref()) {
+      (None, Some(kind)) => RustTypesMapping::get(context, &kind),
+      (Some(reference), None) => RustTypesMapping::get(context, &reference),
+      (_, _) => unimplemented!(),
+    };
 
     let rust_type = if self.required == Required::Optional {
       quote!(Option<#rust_type>)

--- a/xml_schema_derive/src/xsd/attribute_group.rs
+++ b/xml_schema_derive/src/xsd/attribute_group.rs
@@ -19,8 +19,7 @@ pub struct AttributeGroup {
   // pub attribute_group: Vec<AttributeGroup>,
 }
 
-impl AttributeGroup {
-}
+impl AttributeGroup {}
 
 // #[cfg(test)]
 // mod tests {

--- a/xml_schema_derive/src/xsd/complex_type.rs
+++ b/xml_schema_derive/src/xsd/complex_type.rs
@@ -36,7 +36,10 @@ impl ComplexType {
     prefix: &Option<String>,
     context: &XsdContext,
   ) -> TokenStream {
-    let struct_name = Ident::new(&self.name.replace(".", "_").to_camel_case(), Span::call_site());
+    let struct_name = Ident::new(
+      &self.name.replace(".", "_").to_camel_case(),
+      Span::call_site(),
+    );
     info!("Generate sequence");
     let sequence = self
       .sequence

--- a/xml_schema_derive/src/xsd/complex_type.rs
+++ b/xml_schema_derive/src/xsd/complex_type.rs
@@ -1,6 +1,6 @@
 use crate::xsd::{
-  attribute::Attribute, complex_content::ComplexContent, sequence::Sequence,
-  simple_content::SimpleContent, XsdContext,
+  annotation::Annotation, attribute::Attribute, complex_content::ComplexContent,
+  sequence::Sequence, simple_content::SimpleContent, XsdContext,
 };
 use heck::CamelCase;
 use log::{debug, info};
@@ -25,6 +25,8 @@ pub struct ComplexType {
   pub simple_content: Option<SimpleContent>,
   #[yaserde(rename = "complexContent")]
   pub complex_content: Option<ComplexContent>,
+  #[yaserde(rename = "annotation")]
+  pub annotation: Option<Annotation>,
 }
 
 impl ComplexType {
@@ -71,7 +73,15 @@ impl ComplexType {
       .map(|sequence| sequence.get_sub_types_implementation(context, &namespace_definition, prefix))
       .unwrap_or_else(|| quote!());
 
+    let docs = self
+      .annotation
+      .as_ref()
+      .map(|annotation| annotation.get_implementation(&namespace_definition, prefix, context))
+      .unwrap_or_else(|| quote!());
+
     quote! {
+      #docs
+
       #[derive(Clone, Debug, Default, PartialEq, YaDeserialize, YaSerialize)]
       #namespace_definition
       pub struct #struct_name {

--- a/xml_schema_derive/src/xsd/element.rs
+++ b/xml_schema_derive/src/xsd/element.rs
@@ -132,7 +132,7 @@ impl Element {
     } else if self.complex_type.first().unwrap().simple_content.is_some() {
       quote!(String)
     } else {
-        println!("{:?}", self);
+      println!("{:?}", self);
       panic!(
         "[Element] {} unimplemented complex type with type: {:?}",
         self.name, self.kind

--- a/xml_schema_derive/src/xsd/element.rs
+++ b/xml_schema_derive/src/xsd/element.rs
@@ -1,6 +1,6 @@
 use crate::xsd::{
-  complex_type::ComplexType, max_occurences::MaxOccurences, rust_types_mapping::RustTypesMapping,
-  XsdContext,
+  annotation::Annotation, complex_type::ComplexType, max_occurences::MaxOccurences,
+  rust_types_mapping::RustTypesMapping, XsdContext,
 };
 use heck::{CamelCase, SnakeCase};
 use log::{debug, info};
@@ -24,6 +24,8 @@ pub struct Element {
   pub max_occurences: Option<MaxOccurences>,
   #[yaserde(rename = "complexType")]
   pub complex_type: Vec<ComplexType>,
+  #[yaserde(rename = "annotation")]
+  pub annotation: Option<Annotation>,
 }
 
 impl Element {
@@ -59,7 +61,14 @@ impl Element {
         .collect()
     };
 
+    let docs = self
+      .annotation
+      .as_ref()
+      .map(|annotation| annotation.get_implementation(&namespace_definition, prefix, context))
+      .unwrap_or_else(|| quote!());
+
     quote! {
+      #docs
       #[derive(Clone, Debug, Default, PartialEq, YaDeserialize, YaSerialize)]
       #namespace_definition
       pub struct #struct_name {
@@ -156,6 +165,8 @@ mod tests {
   static DERIVES: &str =
     "# [ derive ( Clone , Debug , Default , PartialEq , YaDeserialize , YaSerialize ) ] ";
 
+  static DOCS: &str = r#"# [ doc = "Loudness measured in Decibels" ] "#;
+
   #[test]
   fn extern_type() {
     let element = Element {
@@ -165,6 +176,11 @@ mod tests {
       min_occurences: None,
       max_occurences: None,
       complex_type: vec![],
+      annotation: Some(Annotation {
+        id: None,
+        attributes: vec![],
+        documentation: vec!["Loudness measured in Decibels".to_string()],
+      }),
     };
 
     let context =
@@ -176,8 +192,8 @@ mod tests {
     assert_eq!(
       ts.to_string(),
       format!(
-        "{}pub struct Volume {{ # [ yaserde ( flatten ) ] pub content : VolumeType , }}",
-        DERIVES
+        "{}{}pub struct Volume {{ # [ yaserde ( flatten ) ] pub content : VolumeType , }}",
+        DOCS, DERIVES
       )
     );
   }
@@ -191,6 +207,11 @@ mod tests {
       min_occurences: None,
       max_occurences: None,
       complex_type: vec![],
+      annotation: Some(Annotation {
+        id: None,
+        attributes: vec![],
+        documentation: vec!["Loudness measured in Decibels".to_string()],
+      }),
     };
 
     let context =
@@ -202,8 +223,8 @@ mod tests {
     assert_eq!(
       ts.to_string(),
       format!(
-        "{}pub struct Volume {{ # [ yaserde ( text ) ] pub content : String , }}",
-        DERIVES
+        "{}{}pub struct Volume {{ # [ yaserde ( text ) ] pub content : String , }}",
+        DOCS, DERIVES
       )
     );
   }

--- a/xml_schema_derive/src/xsd/mod.rs
+++ b/xml_schema_derive/src/xsd/mod.rs
@@ -1,3 +1,4 @@
+mod annotation;
 mod attribute;
 mod attribute_group;
 mod complex_content;

--- a/xml_schema_derive/src/xsd/mod.rs
+++ b/xml_schema_derive/src/xsd/mod.rs
@@ -61,12 +61,11 @@ impl Xsd {
     };
 
     // skip BOM header, can be present on some files
-    let content =
-      if &content.as_bytes()[0..3] == [0xef, 0xbb, 0xbf] {
-        content[3..].to_owned()
-      } else {
-        content
-      };
+    let content = if &content.as_bytes()[0..3] == [0xef, 0xbb, 0xbf] {
+      content[3..].to_owned()
+    } else {
+      content
+    };
 
     Xsd::new(&content, module_namespace_mappings)
   }

--- a/xml_schema_derive/src/xsd/schema.rs
+++ b/xml_schema_derive/src/xsd/schema.rs
@@ -1,4 +1,6 @@
-use crate::xsd::{attribute, attribute_group, complex_type, element, import, qualification, simple_type, XsdContext};
+use crate::xsd::{
+  attribute, attribute_group, complex_type, element, import, qualification, simple_type, XsdContext,
+};
 use log::{debug, info};
 use proc_macro2::TokenStream;
 use std::io::prelude::*;

--- a/xml_schema_derive/src/xsd/simple_type.rs
+++ b/xml_schema_derive/src/xsd/simple_type.rs
@@ -34,7 +34,7 @@ impl SimpleType {
       #namespace_definition
       pub struct #struct_name {
         #[yaserde(text)]
-        pub content: String,
+        pub content: std::string::String,
       }
     )
   }
@@ -64,11 +64,12 @@ mod tests {
       .get_implementation(&quote!(), &None, &context)
       .to_string();
 
-    assert!(
-      ts == format!(
-        "{}pub struct Test {{ # [ yaserde ( text ) ] pub content : String , }}",
+    assert_eq!(
+      format!(
+        "{}pub struct Test {{ # [ yaserde ( text ) ] pub content : std :: string :: String , }}",
         DERIVES
-      )
+      ),
+      ts
     );
   }
 


### PR DESCRIPTION
This adds documentation to `complexTypes` and `elements` for now.
You can find a usage example [here](https://github.com/marcelbuesing/arxml) via `cargo doc --open`.
There is also some minor String change included.
This is due to "Autosar XML" defining it's own "STRING" complexType, this leads to naming collisions between `std::string::String` and the generated `struct String`. I will create a PR for yaserde regarding this.