### PR TITLE
Use modules to avoid conflicts between types

### DIFF
--- a/xml_schema/tests/complex_type.rs
+++ b/xml_schema/tests/complex_type.rs
@@ -1,12 +1,6 @@
-#[macro_use]
-extern crate yaserde_derive;
-
-use log::debug;
-use std::io::prelude::*;
 use xml_schema_derive::XmlSchema;
 use yaserde::de::from_str;
 use yaserde::ser::to_string;
-use yaserde::{YaDeserialize, YaSerialize};
 
 #[test]
 fn complex_type_string() {
@@ -22,9 +16,9 @@ fn complex_type_string() {
   </ComplexListOfElements>
   "#;
 
-  let sample_1: ComplexListOfElements = from_str(xml_1).unwrap();
+  let sample_1: types::ComplexListOfElements = from_str(xml_1).unwrap();
 
-  let model = ComplexListOfElements {
+  let model = types::ComplexListOfElements {
     annotation: Some("Test content".to_string()),
     label: "Label content".to_string(),
   };

--- a/xml_schema/tests/simple_type.rs
+++ b/xml_schema/tests/simple_type.rs
@@ -1,12 +1,6 @@
-#[macro_use]
-extern crate yaserde_derive;
-
-use log::debug;
-use std::io::prelude::*;
 use xml_schema_derive::XmlSchema;
 use yaserde::de::from_str;
 use yaserde::ser::to_string;
-use yaserde::{YaDeserialize, YaSerialize};
 
 #[test]
 fn simple_type_string() {
@@ -24,9 +18,9 @@ fn simple_type_string() {
   </Sample-type>
   "#;
 
-  let sample_1: SampleType = from_str(xml_1).unwrap();
+  let sample_1: types::SampleType = from_str(xml_1).unwrap();
 
-  let model = SampleType {
+  let model = types::SampleType {
     content: "Test content".to_string(),
   };
 
@@ -44,14 +38,14 @@ fn simple_type_list() {
   <BaseType strings="value1 value2" integers="3 6" booleans="true false" />
   "#;
 
-  let sample_1: BaseType = from_str(xml_1).unwrap();
+  let sample_1: types::BaseType = from_str(xml_1).unwrap();
 
-  let model = BaseType {
-    strings: Some(StringList {
+  let model = types::BaseType {
+    strings: Some(types::StringList {
       items: vec!["value1".to_string(), "value2".to_string()],
     }),
-    integers: Some(IntegerList { items: vec![3, 6] }),
-    booleans: Some(BooleanList {
+    integers: Some(types::IntegerList { items: vec![3, 6] }),
+    booleans: Some(types::BooleanList {
       items: vec![true, false],
     }),
   };

--- a/xml_schema_derive/src/expander.rs
+++ b/xml_schema_derive/src/expander.rs
@@ -9,7 +9,12 @@ pub fn expand_derive(ast: &syn::DeriveInput) -> Result<TokenStream, String> {
 
   info!("{:?}", attributes);
 
-  let xsd = Xsd::new_from_file(&attributes.source, &attributes.module_namespace_mappings)?;
+  let xsd = Xsd::new_from_file(
+    ast.ident.to_string(),
+    ast.vis.clone(),
+    &attributes.source,
+    &attributes.module_namespace_mappings,
+  )?;
   let generated = xsd.implement(&attributes.target_prefix);
 
   if let Some(store_generated_code) = &attributes.store_generated_code {

--- a/xml_schema_derive/src/xsd/element.rs
+++ b/xml_schema_derive/src/xsd/element.rs
@@ -54,7 +54,7 @@ impl Implementation for Element {
       (
         quote!(
           #[yaserde(#subtype_mode)]
-          pub content: #extern_type,
+          pub content: types::#extern_type,
         ),
         quote!(),
       )

--- a/xml_schema_derive/src/xsd/list.rs
+++ b/xml_schema_derive/src/xsd/list.rs
@@ -24,7 +24,7 @@ impl Implementation for List {
     quote!(
       #[derive(Clone, Debug, Default, PartialEq)]
       pub struct #struct_name {
-        items: Vec<#list_type>
+        pub items: Vec<#list_type>
       }
 
       impl YaDeserialize for #struct_name {

--- a/xml_schema_derive/src/xsd/mod.rs
+++ b/xml_schema_derive/src/xsd/mod.rs
@@ -18,10 +18,12 @@ mod simple_type;
 mod union;
 mod xsd_context;
 
+use heck::SnakeCase;
 use log::info;
 use proc_macro2::{Ident, TokenStream};
 use std::collections::BTreeMap;
 use std::fs;
+use syn::Visibility;
 use xsd_context::XsdContext;
 use yaserde::de::from_str;
 
@@ -48,12 +50,16 @@ trait Implementation {
 
 #[derive(Clone, Debug)]
 pub struct Xsd {
+  name: String,
+  vis: Visibility,
   context: XsdContext,
   schema: schema::Schema,
 }
 
 impl Xsd {
   pub fn new(
+    name: String,
+    vis: Visibility,
     content: &str,
     module_namespace_mappings: &BTreeMap<String, String>,
   ) -> Result<Self, String> {
@@ -61,10 +67,17 @@ impl Xsd {
     let context = context.with_module_namespace_mappings(module_namespace_mappings);
     let schema: schema::Schema = from_str(content)?;
 
-    Ok(Xsd { context, schema })
+    Ok(Xsd {
+      name,
+      vis,
+      context,
+      schema,
+    })
   }
 
   pub fn new_from_file(
+    name: String,
+    vis: Visibility,
     source: &str,
     module_namespace_mappings: &BTreeMap<String, String>,
   ) -> Result<Self, String> {
@@ -88,12 +101,23 @@ impl Xsd {
       content
     };
 
-    Xsd::new(&content, module_namespace_mappings)
+    Xsd::new(name, vis, &content, module_namespace_mappings)
   }
 
   pub fn implement(&self, target_prefix: &Option<String>) -> TokenStream {
-    self
+    let schema = self
       .schema
-      .implement(&TokenStream::new(), target_prefix, &self.context)
+      .implement(&TokenStream::new(), target_prefix, &self.context);
+
+    let mod_name = format_ident!("{}", self.name.to_snake_case());
+    let vis = &self.vis;
+
+    quote! {
+        mod #mod_name {
+            #schema
+        }
+
+        #vis use #mod_name::*;
+    }
   }
 }

--- a/xml_schema_derive/src/xsd/schema.rs
+++ b/xml_schema_derive/src/xsd/schema.rs
@@ -65,8 +65,21 @@ impl Implementation for Schema {
       .collect();
 
     quote!(
-      #simple_types
-      #complex_types
+      pub mod types {
+          use yaserde::{YaDeserialize, YaSerialize};
+          use yaserde_derive::{YaDeserialize, YaSerialize};
+          use std::io::{Read, Write};
+          use xml::reader::{EventReader, XmlEvent};
+
+          #simple_types
+          #complex_types
+      }
+
+      use yaserde::{YaDeserialize, YaSerialize};
+      use yaserde_derive::{YaDeserialize, YaSerialize};
+      use std::io::{Read, Write};
+      use xml::reader::{EventReader, XmlEvent};
+
       #elements
     )
   }


### PR DESCRIPTION
* Complex and simple types are put in a nested `types` module.
* A module is crates with the snake_case name of the original `Struct`. This should help avoiding conflicts between different xsds and it also allow auto-use all the needed traits without duplications within the same scope.
* The visibility of the derived struct is forwarded to the module, in order to easily export inner structs. Please let me know if this feature is desired or not.

The main problem of this PR is that introduces breaking changes, because the simple and complex types have a different path.

Closes #11