### PR TITLE
fix tests broken by TokenStream::to_string() change in proc_macro2 1.0.20

### DIFF
--- a/xml_schema_derive/src/xsd/attribute.rs
+++ b/xml_schema_derive/src/xsd/attribute.rs
@@ -98,6 +98,7 @@ impl Implementation for Attribute {
 
 #[cfg(test)]
 mod tests {
+  use std::str::FromStr;
   use super::*;
 
   #[test]
@@ -125,7 +126,7 @@ mod tests {
     );
     assert_eq!(
       implementation,
-      r#"# [ yaserde ( attribute ) ] pub language : String ,"#
+      TokenStream::from_str(r#"# [ yaserde ( attribute ) ] pub language : String ,"#).unwrap().to_string()
     );
   }
 
@@ -149,7 +150,7 @@ mod tests {
     );
     assert_eq!(
       implementation,
-      r#"# [ yaserde ( attribute ) ] pub language : Option < String > ,"#
+      TokenStream::from_str(r#"# [ yaserde ( attribute ) ] pub language : Option < String > ,"#).unwrap().to_string()
     );
   }
 
@@ -173,7 +174,7 @@ mod tests {
     );
     assert_eq!(
       implementation,
-      r#"# [ yaserde ( attribute , rename = "type" ) ] pub kind : Option < String > ,"#
+      TokenStream::from_str(r#"# [ yaserde ( attribute , rename = "type" ) ] pub kind : Option < String > ,"#).unwrap().to_string()
     );
   }
 
@@ -197,7 +198,7 @@ mod tests {
     );
     assert_eq!(
       implementation,
-      r#"# [ yaserde ( attribute , rename = "type" ) ] pub kind : Option < MyType > ,"#
+      TokenStream::from_str(r#"# [ yaserde ( attribute , rename = "type" ) ] pub kind : Option < MyType > ,"#).unwrap().to_string()
     );
   }
 

--- a/xml_schema_derive/src/xsd/attribute.rs
+++ b/xml_schema_derive/src/xsd/attribute.rs
@@ -98,8 +98,8 @@ impl Implementation for Attribute {
 
 #[cfg(test)]
 mod tests {
-  use std::str::FromStr;
   use super::*;
+  use std::str::FromStr;
 
   #[test]
   fn default_required() {
@@ -126,7 +126,9 @@ mod tests {
     );
     assert_eq!(
       implementation,
-      TokenStream::from_str(r#"# [ yaserde ( attribute ) ] pub language : String ,"#).unwrap().to_string()
+      TokenStream::from_str(r#"# [ yaserde ( attribute ) ] pub language : String ,"#)
+        .unwrap()
+        .to_string()
     );
   }
 
@@ -150,7 +152,9 @@ mod tests {
     );
     assert_eq!(
       implementation,
-      TokenStream::from_str(r#"# [ yaserde ( attribute ) ] pub language : Option < String > ,"#).unwrap().to_string()
+      TokenStream::from_str(r#"# [ yaserde ( attribute ) ] pub language : Option < String > ,"#)
+        .unwrap()
+        .to_string()
     );
   }
 
@@ -174,7 +178,11 @@ mod tests {
     );
     assert_eq!(
       implementation,
-      TokenStream::from_str(r#"# [ yaserde ( attribute , rename = "type" ) ] pub kind : Option < String > ,"#).unwrap().to_string()
+      TokenStream::from_str(
+        r#"# [ yaserde ( attribute , rename = "type" ) ] pub kind : Option < String > ,"#
+      )
+      .unwrap()
+      .to_string()
     );
   }
 
@@ -198,7 +206,11 @@ mod tests {
     );
     assert_eq!(
       implementation,
-      TokenStream::from_str(r#"# [ yaserde ( attribute , rename = "type" ) ] pub kind : Option < MyType > ,"#).unwrap().to_string()
+      TokenStream::from_str(
+        r#"# [ yaserde ( attribute , rename = "type" ) ] pub kind : Option < MyType > ,"#
+      )
+      .unwrap()
+      .to_string()
     );
   }
 

--- a/xml_schema_derive/src/xsd/element.rs
+++ b/xml_schema_derive/src/xsd/element.rs
@@ -164,8 +164,8 @@ impl Element {
 
 #[cfg(test)]
 mod tests {
-  use std::str::FromStr;
   use super::*;
+  use std::str::FromStr;
 
   static DERIVES: &str =
     "# [ derive ( Clone , Debug , Default , PartialEq , YaDeserialize , YaSerialize ) ] ";
@@ -197,10 +197,15 @@ mod tests {
 
     assert_eq!(
       ts.to_string(),
-      TokenStream::from_str(format!(
-        "{}{}pub struct Volume {{ # [ yaserde ( flatten ) ] pub content : VolumeType , }}",
-        DOCS, DERIVES
-      ).as_str()).unwrap().to_string()
+      TokenStream::from_str(
+        format!(
+          "{}{}pub struct Volume {{ # [ yaserde ( flatten ) ] pub content : VolumeType , }}",
+          DOCS, DERIVES
+        )
+        .as_str()
+      )
+      .unwrap()
+      .to_string()
     );
   }
 
@@ -229,10 +234,15 @@ mod tests {
 
     assert_eq!(
       ts.to_string(),
-      TokenStream::from_str(format!(
-        "{}{}pub struct Volume {{ # [ yaserde ( text ) ] pub content : String , }}",
-        DOCS, DERIVES
-      ).as_str()).unwrap().to_string()
+      TokenStream::from_str(
+        format!(
+          "{}{}pub struct Volume {{ # [ yaserde ( text ) ] pub content : String , }}",
+          DOCS, DERIVES
+        )
+        .as_str()
+      )
+      .unwrap()
+      .to_string()
     );
   }
 }

--- a/xml_schema_derive/src/xsd/element.rs
+++ b/xml_schema_derive/src/xsd/element.rs
@@ -164,6 +164,7 @@ impl Element {
 
 #[cfg(test)]
 mod tests {
+  use std::str::FromStr;
   use super::*;
 
   static DERIVES: &str =
@@ -196,10 +197,10 @@ mod tests {
 
     assert_eq!(
       ts.to_string(),
-      format!(
+      TokenStream::from_str(format!(
         "{}{}pub struct Volume {{ # [ yaserde ( flatten ) ] pub content : VolumeType , }}",
         DOCS, DERIVES
-      )
+      ).as_str()).unwrap().to_string()
     );
   }
 
@@ -228,10 +229,10 @@ mod tests {
 
     assert_eq!(
       ts.to_string(),
-      format!(
+      TokenStream::from_str(format!(
         "{}{}pub struct Volume {{ # [ yaserde ( text ) ] pub content : String , }}",
         DOCS, DERIVES
-      )
+      ).as_str()).unwrap().to_string()
     );
   }
 }

--- a/xml_schema_derive/src/xsd/extension.rs
+++ b/xml_schema_derive/src/xsd/extension.rs
@@ -64,8 +64,8 @@ impl Extension {
 
 #[cfg(test)]
 mod tests {
-  use std::str::FromStr;
   use super::*;
+  use std::str::FromStr;
 
   #[test]
   fn extension() {
@@ -82,7 +82,12 @@ mod tests {
     let ts = st
       .implement(&TokenStream::new(), &None, &context)
       .to_string();
-    assert_eq!(ts, TokenStream::from_str("# [ yaserde ( text ) ] pub content : String ,").unwrap().to_string());
+    assert_eq!(
+      ts,
+      TokenStream::from_str("# [ yaserde ( text ) ] pub content : String ,")
+        .unwrap()
+        .to_string()
+    );
   }
 
   #[test]

--- a/xml_schema_derive/src/xsd/extension.rs
+++ b/xml_schema_derive/src/xsd/extension.rs
@@ -64,6 +64,7 @@ impl Extension {
 
 #[cfg(test)]
 mod tests {
+  use std::str::FromStr;
   use super::*;
 
   #[test]
@@ -81,7 +82,7 @@ mod tests {
     let ts = st
       .implement(&TokenStream::new(), &None, &context)
       .to_string();
-    assert!(ts == "# [ yaserde ( text ) ] pub content : String ,");
+    assert_eq!(ts, TokenStream::from_str("# [ yaserde ( text ) ] pub content : String ,").unwrap().to_string());
   }
 
   #[test]
@@ -116,6 +117,6 @@ mod tests {
     let ts = st
       .implement(&TokenStream::new(), &None, &context)
       .to_string();
-    assert!(ts == "# [ yaserde ( text ) ] pub content : String , # [ yaserde ( attribute ) ] pub attribute_1 : String , # [ yaserde ( attribute ) ] pub attribute_2 : Option < bool > ,");
+    assert_eq!(ts, TokenStream::from_str("# [ yaserde ( text ) ] pub content : String , # [ yaserde ( attribute ) ] pub attribute_1 : String , # [ yaserde ( attribute ) ] pub attribute_2 : Option < bool > ,").unwrap().to_string());
   }
 }

--- a/xml_schema_derive/src/xsd/list.rs
+++ b/xml_schema_derive/src/xsd/list.rs
@@ -71,6 +71,7 @@ impl Implementation for List {
 
 #[cfg(test)]
 mod tests {
+  use std::str::FromStr;
   use super::*;
   use proc_macro2::Span;
   use syn::Ident;
@@ -94,7 +95,7 @@ mod tests {
 
     assert_eq!(
       implementation,
-      r#"# [ derive ( Clone , Debug , Default , PartialEq ) ] pub struct Parent { items : Vec < String > } impl YaDeserialize for Parent { fn deserialize < R : Read > ( reader : & mut yaserde :: de :: Deserializer < R > ) -> Result < Self , String > { loop { match reader . next_event ( ) ? { xml :: reader :: XmlEvent :: StartElement { .. } => { } xml :: reader :: XmlEvent :: Characters ( ref text_content ) => { let items : Vec < String > = text_content . split ( ' ' ) . map ( | item | item . to_owned ( ) ) . map ( | item | item . parse ( ) . unwrap ( ) ) . collect ( ) ; return Ok ( Parent { items } ) ; } _ => { break ; } } } Err ( "Unable to parse attribute" . to_string ( ) ) } } impl YaSerialize for Parent { fn serialize < W : Write > ( & self , writer : & mut yaserde :: ser :: Serializer < W > ) -> Result < ( ) , String > { let content = self . items . iter ( ) . map ( | item | item . to_string ( ) ) . collect :: < Vec < String >> ( ) . join ( " " ) ; let data_event = xml :: writer :: XmlEvent :: characters ( & content ) ; writer . write ( data_event ) . map_err ( | e | e . to_string ( ) ) ? ; Ok ( ( ) ) } fn serialize_attributes ( & self , mut source_attributes : Vec < xml :: attribute :: OwnedAttribute > , mut source_namespace : xml :: namespace :: Namespace ) -> Result < ( Vec < xml :: attribute :: OwnedAttribute > , xml :: namespace :: Namespace ) , String > { Ok ( ( source_attributes , source_namespace ) ) } }"#
+      TokenStream::from_str(r#"# [ derive ( Clone , Debug , Default , PartialEq ) ] pub struct Parent { items : Vec < String > } impl YaDeserialize for Parent { fn deserialize < R : Read > ( reader : & mut yaserde :: de :: Deserializer < R > ) -> Result < Self , String > { loop { match reader . next_event ( ) ? { xml :: reader :: XmlEvent :: StartElement { .. } => { } xml :: reader :: XmlEvent :: Characters ( ref text_content ) => { let items : Vec < String > = text_content . split ( ' ' ) . map ( | item | item . to_owned ( ) ) . map ( | item | item . parse ( ) . unwrap ( ) ) . collect ( ) ; return Ok ( Parent { items } ) ; } _ => { break ; } } } Err ( "Unable to parse attribute" . to_string ( ) ) } } impl YaSerialize for Parent { fn serialize < W : Write > ( & self , writer : & mut yaserde :: ser :: Serializer < W > ) -> Result < ( ) , String > { let content = self . items . iter ( ) . map ( | item | item . to_string ( ) ) . collect :: < Vec < String >> ( ) . join ( " " ) ; let data_event = xml :: writer :: XmlEvent :: characters ( & content ) ; writer . write ( data_event ) . map_err ( | e | e . to_string ( ) ) ? ; Ok ( ( ) ) } fn serialize_attributes ( & self , mut source_attributes : Vec < xml :: attribute :: OwnedAttribute > , mut source_namespace : xml :: namespace :: Namespace ) -> Result < ( Vec < xml :: attribute :: OwnedAttribute > , xml :: namespace :: Namespace ) , String > { Ok ( ( source_attributes , source_namespace ) ) } }"#).unwrap().to_string()
     );
   }
 }

--- a/xml_schema_derive/src/xsd/list.rs
+++ b/xml_schema_derive/src/xsd/list.rs
@@ -71,9 +71,9 @@ impl Implementation for List {
 
 #[cfg(test)]
 mod tests {
-  use std::str::FromStr;
   use super::*;
   use proc_macro2::Span;
+  use std::str::FromStr;
   use syn::Ident;
 
   #[test]

--- a/xml_schema_derive/src/xsd/schema.rs
+++ b/xml_schema_derive/src/xsd/schema.rs
@@ -93,8 +93,8 @@ fn generate_namespace_definition(
 
 #[cfg(test)]
 mod tests {
-  use std::str::FromStr;
   use super::*;
+  use std::str::FromStr;
 
   #[test]
   fn default_schema_implementation() {
@@ -144,7 +144,11 @@ mod tests {
 
     assert_eq!(
       implementation,
-      TokenStream::from_str(r#"# [ yaserde ( prefix = "prefix" , namespace = "prefix: http://example.com" ) ]"#).unwrap().to_string()
+      TokenStream::from_str(
+        r#"# [ yaserde ( prefix = "prefix" , namespace = "prefix: http://example.com" ) ]"#
+      )
+      .unwrap()
+      .to_string()
     );
   }
 }

--- a/xml_schema_derive/src/xsd/schema.rs
+++ b/xml_schema_derive/src/xsd/schema.rs
@@ -93,6 +93,7 @@ fn generate_namespace_definition(
 
 #[cfg(test)]
 mod tests {
+  use std::str::FromStr;
   use super::*;
 
   #[test]
@@ -143,7 +144,7 @@ mod tests {
 
     assert_eq!(
       implementation,
-      r#"# [ yaserde ( prefix = "prefix" , namespace = "prefix: http://example.com" ) ]"#
+      TokenStream::from_str(r#"# [ yaserde ( prefix = "prefix" , namespace = "prefix: http://example.com" ) ]"#).unwrap().to_string()
     );
   }
 }

--- a/xml_schema_derive/src/xsd/simple_type.rs
+++ b/xml_schema_derive/src/xsd/simple_type.rs
@@ -56,6 +56,7 @@ impl SimpleType {
 
 #[cfg(test)]
 mod tests {
+  use std::str::FromStr;
   use super::*;
 
   static DERIVES: &str =
@@ -77,10 +78,10 @@ mod tests {
     let ts = st.implement(&quote!(), &None, &context).to_string();
 
     assert_eq!(
-      format!(
+      TokenStream::from_str(format!(
         "{}pub struct Test {{ # [ yaserde ( text ) ] pub content : std :: string :: String , }}",
         DERIVES
-      ),
+      ).as_str()).unwrap().to_string(),
       ts
     );
   }

--- a/xml_schema_derive/src/xsd/simple_type.rs
+++ b/xml_schema_derive/src/xsd/simple_type.rs
@@ -56,8 +56,8 @@ impl SimpleType {
 
 #[cfg(test)]
 mod tests {
-  use std::str::FromStr;
   use super::*;
+  use std::str::FromStr;
 
   static DERIVES: &str =
     "# [ derive ( Clone , Debug , Default , PartialEq , YaDeserialize , YaSerialize ) ] ";
@@ -78,10 +78,15 @@ mod tests {
     let ts = st.implement(&quote!(), &None, &context).to_string();
 
     assert_eq!(
-      TokenStream::from_str(format!(
-        "{}pub struct Test {{ # [ yaserde ( text ) ] pub content : std :: string :: String , }}",
-        DERIVES
-      ).as_str()).unwrap().to_string(),
+      TokenStream::from_str(
+        format!(
+          "{}pub struct Test {{ # [ yaserde ( text ) ] pub content : std :: string :: String , }}",
+          DERIVES
+        )
+        .as_str()
+      )
+      .unwrap()
+      .to_string(),
       ts
     );
   }


### PR DESCRIPTION
see commit https://github.com/dtolnay/proc-macro2/commit/bef084bb724c8885a3045183f44492ff1016ba6c
It changed whitespace generation inside groups.

By converting strings to tokens and back to strings we won't depend on further possible formatting changes.