### PR TITLE
initial choice type support

### DIFF
--- a/xml_schema/tests/choice.rs
+++ b/xml_schema/tests/choice.rs
@@ -16,19 +16,19 @@ fn choice() {
 
   let xml_1 = r#"
   <?xml version="1.0" encoding="UTF-8"?>
-  <Parent>
-    <XFirstname>John</XFirstname>
-  </Parent>
+  <person>
+    <firstname>John</firstname>
+  </person>
   "#;
 
-  let sample_1: Parent = from_str(xml_1).unwrap();
+  let sample_1: Person = from_str(xml_1).unwrap();
 
-  let model = Parent {
-    x_firstname: Some(Firstname {
+  let model = Person {
+    firstname: Some(Firstname {
       content: "John".to_string(),
       scope: None,
     }),
-    x_lastname: None,
+    lastname: None,
   };
 
   assert_eq!(sample_1, model);
@@ -36,7 +36,7 @@ fn choice() {
   let data = to_string(&model).unwrap();
   assert_eq!(
     data,
-    r#"<?xml version="1.0" encoding="utf-8"?><Parent><XFirstname>John</XFirstname></Parent>"#
+    r#"<?xml version="1.0" encoding="utf-8"?><Person><firstname>John</firstname></Person>"#
   );
 }
 
@@ -70,6 +70,6 @@ fn choice_sequence() {
   let data = to_string(&model).unwrap();
   assert_eq!(
     data,
-    r#"<?xml version="1.0" encoding="utf-8"?><person><name>Doe</name><firstname>John</firstname></person>"#
+    r#"<?xml version="1.0" encoding="utf-8"?><Person><name>Doe</name><firstname>John</firstname></Person>"#
   );
 }

--- a/xml_schema/tests/choice.rs
+++ b/xml_schema/tests/choice.rs
@@ -1,0 +1,41 @@
+#[macro_use]
+extern crate yaserde_derive;
+
+use log::debug;
+use std::io::prelude::*;
+use xml_schema_derive::XmlSchema;
+use yaserde::de::from_str;
+use yaserde::ser::to_string;
+use yaserde::{YaDeserialize, YaSerialize};
+
+#[test]
+fn choice() {
+  #[derive(Debug, XmlSchema)]
+  #[xml_schema(source = "xml_schema/tests/choice.xsd")]
+  struct ChoiceTypeSchema;
+
+  let xml_1 = r#"
+  <?xml version="1.0" encoding="UTF-8"?>
+  <Parent>
+    <XFirstname>John</XFirstname>
+  </Parent>
+  "#;
+
+  let sample_1: Parent = from_str(xml_1).unwrap();
+
+  let model = Parent {
+    x_firstname: Some(Firstname {
+      content: "John".to_string(),
+      scope: None,
+    }),
+    x_lastname: None,
+  };
+
+  assert_eq!(sample_1, model);
+
+  let data = to_string(&model).unwrap();
+  assert_eq!(
+    data,
+    r#"<?xml version="1.0" encoding="utf-8"?><Parent><XFirstname>John</XFirstname></Parent>"#
+  );
+}

--- a/xml_schema/tests/choice.rs
+++ b/xml_schema/tests/choice.rs
@@ -48,21 +48,21 @@ fn choice_sequence() {
 
   let xml_1 = r#"
   <?xml version="1.0" encoding="UTF-8"?>
-  <Parent>
-    <Name>Doe</Name>
-    <XFirstname>John</XFirstname>
-  </Parent>
+  <person>
+    <name>Doe</name>
+    <firstname>John</firstname>
+  </person>
   "#;
 
-  let sample_1: Parent = from_str(xml_1).unwrap();
+  let sample_1: Person = from_str(xml_1).unwrap();
 
-  let model = Parent {
+  let model = Person {
     name: "Doe".to_string(),
-    x_firstname: Some(Firstname {
+    firstname: Some(Firstname {
       content: "John".to_string(),
       scope: None,
     }),
-    x_lastname: None,
+    lastname: None,
   };
 
   assert_eq!(sample_1, model);
@@ -70,6 +70,6 @@ fn choice_sequence() {
   let data = to_string(&model).unwrap();
   assert_eq!(
     data,
-    r#"<?xml version="1.0" encoding="utf-8"?><Parent><Name>Doe</Name><XFirstname>John</XFirstname></Parent>"#
+    r#"<?xml version="1.0" encoding="utf-8"?><person><name>Doe</name><firstname>John</firstname></person>"#
   );
 }

--- a/xml_schema/tests/choice.rs
+++ b/xml_schema/tests/choice.rs
@@ -73,3 +73,32 @@ fn choice_sequence() {
     r#"<?xml version="1.0" encoding="utf-8"?><Person><name>Doe</name><firstname>John</firstname></Person>"#
   );
 }
+
+#[test]
+fn choice_multiple() {
+  #[derive(Debug, XmlSchema)]
+  #[xml_schema(source = "xml_schema/tests/choice_multiple.xsd")]
+  struct ChoiceTypeSchema;
+
+  let xml_1 = r#"
+  <?xml version="1.0" encoding="UTF-8"?>
+  <person>
+    <firstname>John</firstname>
+  </person>
+  "#;
+
+  let sample_1: Person = from_str(xml_1).unwrap();
+
+  let model = Person {
+    firstnames: vec!["John".to_string()],
+    lastnames: vec![],
+  };
+
+  assert_eq!(sample_1, model);
+
+  let data = to_string(&model).unwrap();
+  assert_eq!(
+    data,
+    r#"<?xml version="1.0" encoding="utf-8"?><Person><firstname>John</firstname></Person>"#
+  );
+}

--- a/xml_schema/tests/choice.rs
+++ b/xml_schema/tests/choice.rs
@@ -39,3 +39,37 @@ fn choice() {
     r#"<?xml version="1.0" encoding="utf-8"?><Parent><XFirstname>John</XFirstname></Parent>"#
   );
 }
+
+#[test]
+fn choice_sequence() {
+  #[derive(Debug, XmlSchema)]
+  #[xml_schema(source = "xml_schema/tests/choice_sequence.xsd")]
+  struct ChoiceTypeSchema;
+
+  let xml_1 = r#"
+  <?xml version="1.0" encoding="UTF-8"?>
+  <Parent>
+    <Name>Doe</Name>
+    <XFirstname>John</XFirstname>
+  </Parent>
+  "#;
+
+  let sample_1: Parent = from_str(xml_1).unwrap();
+
+  let model = Parent {
+    name: "Doe".to_string(),
+    x_firstname: Some(Firstname {
+      content: "John".to_string(),
+      scope: None,
+    }),
+    x_lastname: None,
+  };
+
+  assert_eq!(sample_1, model);
+
+  let data = to_string(&model).unwrap();
+  assert_eq!(
+    data,
+    r#"<?xml version="1.0" encoding="utf-8"?><Parent><Name>Doe</Name><XFirstname>John</XFirstname></Parent>"#
+  );
+}

--- a/xml_schema/tests/choice.xsd
+++ b/xml_schema/tests/choice.xsd
@@ -1,0 +1,25 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:complexType name="Firstname">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="scope" type="xs:anyURI" use="optional" default="http://example.com#elements"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="Lastname">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="scope" type="xs:anyURI" use="optional" default="http://example.com#elements"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+
+    <xs:complexType name="Parent">
+        <xs:choice maxOccurs="unbounded" minOccurs="0">
+            <xs:element name="XFirstname" type="Firstname"/>
+            <xs:element name="XLastname" type="Lastname"/>
+        </xs:choice>
+    </xs:complexType>
+</xs:schema>

--- a/xml_schema/tests/choice.xsd
+++ b/xml_schema/tests/choice.xsd
@@ -1,5 +1,5 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:complexType name="Firstname">
+    <xs:complexType name="firstname">
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute name="scope" type="xs:anyURI" use="optional" default="http://example.com#elements"/>
@@ -7,7 +7,7 @@
         </xs:simpleContent>
     </xs:complexType>
 
-    <xs:complexType name="Lastname">
+    <xs:complexType name="lastname">
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute name="scope" type="xs:anyURI" use="optional" default="http://example.com#elements"/>
@@ -16,10 +16,10 @@
     </xs:complexType>
 
 
-    <xs:complexType name="Parent">
-        <xs:choice maxOccurs="unbounded" minOccurs="0">
-            <xs:element name="XFirstname" type="Firstname"/>
-            <xs:element name="XLastname" type="Lastname"/>
+    <xs:complexType name="person">
+        <xs:choice minOccurs="0">
+            <xs:element name="firstname" type="firstname"/>
+            <xs:element name="lastname" type="lastname"/>
         </xs:choice>
     </xs:complexType>
 </xs:schema>

--- a/xml_schema/tests/choice_multiple.xsd
+++ b/xml_schema/tests/choice_multiple.xsd
@@ -1,0 +1,10 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="person">
+        <xs:complexType name="parents">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="firstname" type="xs:string"/>
+                <xs:element name="lastname" type="xs:string"/>
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/xml_schema/tests/choice_sequence.xsd
+++ b/xml_schema/tests/choice_sequence.xsd
@@ -1,0 +1,28 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:complexType name="Firstname">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="scope" type="xs:anyURI" use="optional" default="http://example.com#elements"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="Lastname">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="scope" type="xs:anyURI" use="optional" default="http://example.com#elements"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+
+    <xs:complexType name="Parent">
+        <xs:sequence>
+            <xs:element name="Name" type="xsd:string" minOccurs="1"/>
+            <xs:choice>
+                <xs:element name="XFirstname" type="Firstname"/>
+                <xs:element name="XLastname" type="Lastname"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/xml_schema/tests/choice_sequence.xsd
+++ b/xml_schema/tests/choice_sequence.xsd
@@ -1,5 +1,5 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:complexType name="Firstname">
+    <xs:complexType name="firstname">
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute name="scope" type="xs:anyURI" use="optional" default="http://example.com#elements"/>
@@ -7,7 +7,7 @@
         </xs:simpleContent>
     </xs:complexType>
 
-    <xs:complexType name="Lastname">
+    <xs:complexType name="lastname">
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute name="scope" type="xs:anyURI" use="optional" default="http://example.com#elements"/>
@@ -15,14 +15,15 @@
         </xs:simpleContent>
     </xs:complexType>
 
-
-    <xs:complexType name="Parent">
-        <xs:sequence>
-            <xs:element name="Name" type="xsd:string" minOccurs="1"/>
-            <xs:choice>
-                <xs:element name="XFirstname" type="Firstname"/>
-                <xs:element name="XLastname" type="Lastname"/>
-            </xs:choice>
-        </xs:sequence>
-    </xs:complexType>
+    <xs:element name="person">
+        <xs:complexType name="parent">
+            <xs:sequence>
+                <xs:element name="name" type="xs:string" minOccurs="1"/>
+                <xs:choice>
+                    <xs:element name="firstname" type="firstname"/>
+                    <xs:element name="lastname" type="lastname"/>
+                </xs:choice>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
 </xs:schema>

--- a/xml_schema_derive/src/xsd/choice.rs
+++ b/xml_schema_derive/src/xsd/choice.rs
@@ -53,6 +53,20 @@ impl Implementation for Choice {
 }
 
 impl Choice {
+  pub fn get_sub_types_implementation(
+    &self,
+    context: &XsdContext,
+    namespace_definition: &TokenStream,
+    prefix: &Option<String>,
+  ) -> TokenStream {
+    info!("Generate choice sub types implementation");
+    self
+      .element
+      .iter()
+      .map(|element| element.get_subtypes_implementation(namespace_definition, prefix, context))
+      .collect()
+  }
+
   pub fn get_field_implementation(
     &self,
     context: &XsdContext,

--- a/xml_schema_derive/src/xsd/choice.rs
+++ b/xml_schema_derive/src/xsd/choice.rs
@@ -73,10 +73,19 @@ impl Choice {
     prefix: &Option<String>,
   ) -> TokenStream {
     info!("Generate choice elements");
+
+    let multiple = matches!(self.min_occurences, Some(min_occurences) if min_occurences > 1)
+      || matches!(self.max_occurences, Some(MaxOccurences::Unbounded))
+      || matches!(self.max_occurences, Some(MaxOccurences::Number{value}) if value > 1);
+
+    // Element fields are by default declared as Option type due to the nature of the choice element.
+    // Since a vector can also be empty, use Vec<_>, rather than Option<Vec<_>>.
+    let optional = !multiple;
+
     self
       .element
       .iter()
-      .map(|element| element.get_field_implementation(context, prefix, false, true))
+      .map(|element| element.get_field_implementation(context, prefix, multiple, optional))
       .collect()
   }
 }

--- a/xml_schema_derive/src/xsd/choice.rs
+++ b/xml_schema_derive/src/xsd/choice.rs
@@ -1,0 +1,68 @@
+//! The children of a choice are mapped to Option fields.
+//! Generating an enum would have been the better way but the choice element
+//! may not have a name, so it's impossible to name the generated Rust enum.
+//! The enum would have been nice to avoid runtime checks that only a single choice element is used.
+
+use crate::xsd::{
+  annotation::Annotation, attribute::Attribute, element::Element, max_occurences::MaxOccurences,
+  Implementation, XsdContext,
+};
+use log::{debug, info};
+use proc_macro2::TokenStream;
+use std::io::prelude::*;
+use yaserde::YaDeserialize;
+
+#[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
+#[yaserde(
+  rename = "choice"
+  prefix = "xs",
+  namespace = "xs: http://www.w3.org/2001/XMLSchema"
+)]
+pub struct Choice {
+  #[yaserde(attribute)]
+  pub id: Option<String>,
+  #[yaserde(rename = "attribute")]
+  pub attributes: Vec<Attribute>,
+  #[yaserde(rename = "minOccurs", attribute)]
+  pub min_occurences: Option<u64>,
+  #[yaserde(rename = "maxOccurs", attribute)]
+  pub max_occurences: Option<MaxOccurences>,
+  #[yaserde(rename = "annotation")]
+  pub annotation: Option<Annotation>,
+  #[yaserde(rename = "element")]
+  pub element: Vec<Element>,
+}
+
+impl Implementation for Choice {
+  fn implement(
+    &self,
+    namespace_definition: &TokenStream,
+    prefix: &Option<String>,
+    context: &XsdContext,
+  ) -> TokenStream {
+    let elements: TokenStream = self
+      .element
+      .iter()
+      .map(|element| element.implement(&namespace_definition, prefix, context))
+      .collect();
+
+    quote! {
+      #elements
+    }
+  }
+}
+
+impl Choice {
+  pub fn get_field_implementation(
+    &self,
+    context: &XsdContext,
+    prefix: &Option<String>,
+  ) -> TokenStream {
+    info!("Generate choice elements");
+    self
+      .element
+      .iter()
+      .map(|element| element.get_field_implementation(context, prefix, false, true))
+      .collect()
+  }
+}

--- a/xml_schema_derive/src/xsd/complex_type.rs
+++ b/xml_schema_derive/src/xsd/complex_type.rs
@@ -20,6 +20,7 @@ pub struct ComplexType {
   pub name: String,
   #[yaserde(rename = "attribute")]
   pub attributes: Vec<Attribute>,
+  #[yaserde(rename = "sequence")]
   pub sequence: Option<Sequence>,
   #[yaserde(rename = "simpleContent")]
   pub simple_content: Option<SimpleContent>,

--- a/xml_schema_derive/src/xsd/complex_type.rs
+++ b/xml_schema_derive/src/xsd/complex_type.rs
@@ -130,12 +130,20 @@ impl ComplexType {
         .as_ref()
         .map(|sequence| sequence.get_field_implementation(context, prefix))
         .unwrap_or_else(TokenStream::new)
-    } else {
+    } else if self.simple_content.is_some() {
       self
         .simple_content
         .as_ref()
         .map(|simple_content| simple_content.get_field_implementation(context, prefix))
         .unwrap_or_else(TokenStream::new)
+    } else if self.choice.is_some() {
+      self
+        .choice
+        .as_ref()
+        .map(|choice| choice.get_field_implementation(context, prefix))
+        .unwrap_or_else(TokenStream::new)
+    } else {
+      TokenStream::new()
     }
   }
 

--- a/xml_schema_derive/src/xsd/complex_type.rs
+++ b/xml_schema_derive/src/xsd/complex_type.rs
@@ -75,7 +75,7 @@ impl Implementation for ComplexType {
       .map(|attribute| attribute.implement(&namespace_definition, prefix, context))
       .collect();
 
-    let sub_types_implementation = self
+    let sequence_sub_types = self
       .sequence
       .as_ref()
       .map(|sequence| sequence.get_sub_types_implementation(context, &namespace_definition, prefix))
@@ -87,10 +87,10 @@ impl Implementation for ComplexType {
       .map(|annotation| annotation.implement(&namespace_definition, prefix, context))
       .unwrap_or_else(TokenStream::new);
 
-    let choice = self
+    let choice_sub_types = self
       .choice
       .as_ref()
-      .map(|choice| choice.implement(&namespace_definition, prefix, context))
+      .map(|choice| choice.get_sub_types_implementation(context, &namespace_definition, prefix))
       .unwrap_or_else(TokenStream::new);
 
     let choice_field = self
@@ -112,9 +112,8 @@ impl Implementation for ComplexType {
         #attributes
       }
 
-      #sub_types_implementation
-
-      #choice
+      #sequence_sub_types
+      #choice_sub_types
     }
   }
 }

--- a/xml_schema_derive/src/xsd/complex_type.rs
+++ b/xml_schema_derive/src/xsd/complex_type.rs
@@ -1,5 +1,5 @@
 use crate::xsd::{
-  annotation::Annotation, attribute::Attribute, complex_content::ComplexContent,
+  annotation::Annotation, attribute::Attribute, choice::Choice, complex_content::ComplexContent,
   sequence::Sequence, simple_content::SimpleContent, Implementation, XsdContext,
 };
 use heck::CamelCase;
@@ -27,6 +27,8 @@ pub struct ComplexType {
   pub complex_content: Option<ComplexContent>,
   #[yaserde(rename = "annotation")]
   pub annotation: Option<Annotation>,
+  #[yaserde(rename = "choice")]
+  pub choice: Option<Choice>,
 }
 
 impl Implementation for ComplexType {
@@ -84,6 +86,18 @@ impl Implementation for ComplexType {
       .map(|annotation| annotation.implement(&namespace_definition, prefix, context))
       .unwrap_or_else(TokenStream::new);
 
+    let choice = self
+      .choice
+      .as_ref()
+      .map(|choice| choice.implement(&namespace_definition, prefix, context))
+      .unwrap_or_else(TokenStream::new);
+
+    let choice_field = self
+      .choice
+      .as_ref()
+      .map(|choice| choice.get_field_implementation(context, prefix))
+      .unwrap_or_else(TokenStream::new);
+
     quote! {
       #docs
 
@@ -93,10 +107,13 @@ impl Implementation for ComplexType {
         #sequence
         #simple_content
         #complex_content
+        #choice_field
         #attributes
       }
 
       #sub_types_implementation
+
+      #choice
     }
   }
 }

--- a/xml_schema_derive/src/xsd/element.rs
+++ b/xml_schema_derive/src/xsd/element.rs
@@ -106,6 +106,7 @@ impl Element {
     context: &XsdContext,
     prefix: &Option<String>,
     multiple: bool,
+    optional: bool,
   ) -> TokenStream {
     if self.name == "" {
       return quote!();
@@ -143,7 +144,7 @@ impl Element {
       rust_type
     };
 
-    let rust_type = if self.min_occurences == Some(0) {
+    let rust_type = if optional || self.min_occurences == Some(0) {
       quote!(Option<#rust_type>)
     } else {
       rust_type

--- a/xml_schema_derive/src/xsd/extension.rs
+++ b/xml_schema_derive/src/xsd/extension.rs
@@ -20,6 +20,8 @@ pub struct Extension {
   pub attributes: Vec<Attribute>,
   #[yaserde(rename = "sequence")]
   pub sequences: Vec<Sequence>,
+  #[yaserde(rename = "choice")]
+  pub choices: Vec<Choice>,
 }
 
 impl Implementation for Extension {

--- a/xml_schema_derive/src/xsd/extension.rs
+++ b/xml_schema_derive/src/xsd/extension.rs
@@ -74,6 +74,7 @@ mod tests {
       base: "xs:string".to_string(),
       attributes: vec![],
       sequences: vec![],
+      choices: vec![],
     };
 
     let context =
@@ -109,6 +110,7 @@ mod tests {
         },
       ],
       sequences: vec![],
+      choices: vec![],
     };
 
     let context =

--- a/xml_schema_derive/src/xsd/extension.rs
+++ b/xml_schema_derive/src/xsd/extension.rs
@@ -1,6 +1,6 @@
 use crate::xsd::{
-  attribute::Attribute, rust_types_mapping::RustTypesMapping, sequence::Sequence, Implementation,
-  XsdContext,
+  attribute::Attribute, choice::Choice, rust_types_mapping::RustTypesMapping, sequence::Sequence,
+  Implementation, XsdContext,
 };
 use log::debug;
 use proc_macro2::TokenStream;

--- a/xml_schema_derive/src/xsd/mod.rs
+++ b/xml_schema_derive/src/xsd/mod.rs
@@ -1,6 +1,7 @@
 mod annotation;
 mod attribute;
 mod attribute_group;
+mod choice;
 mod complex_content;
 mod complex_type;
 mod element;

--- a/xml_schema_derive/src/xsd/sequence.rs
+++ b/xml_schema_derive/src/xsd/sequence.rs
@@ -22,7 +22,7 @@ impl Implementation for Sequence {
     self
       .elements
       .iter()
-      .map(|element| element.get_field_implementation(context, prefix, false))
+      .map(|element| element.get_field_implementation(context, prefix, false, false))
       .collect()
   }
 }
@@ -50,7 +50,7 @@ impl Sequence {
     self
       .elements
       .iter()
-      .map(|element| element.get_field_implementation(context, prefix, true))
+      .map(|element| element.get_field_implementation(context, prefix, true, false))
       .collect()
   }
 }

--- a/xml_schema_derive/src/xsd/sequence.rs
+++ b/xml_schema_derive/src/xsd/sequence.rs
@@ -1,4 +1,4 @@
-use crate::xsd::{element::Element, Implementation, XsdContext};
+use crate::xsd::{choice::Choice, element::Element, Implementation, XsdContext};
 use log::{debug, info};
 use proc_macro2::TokenStream;
 use std::io::prelude::*;
@@ -9,6 +9,8 @@ use yaserde::YaDeserialize;
 pub struct Sequence {
   #[yaserde(rename = "element")]
   pub elements: Vec<Element>,
+  #[yaserde(rename = "choice")]
+  pub choices: Vec<Choice>,
 }
 
 impl Implementation for Sequence {
@@ -19,11 +21,22 @@ impl Implementation for Sequence {
     context: &XsdContext,
   ) -> TokenStream {
     info!("Generate elements");
-    self
+    let elements: TokenStream = self
       .elements
       .iter()
       .map(|element| element.get_field_implementation(context, prefix, false, false))
-      .collect()
+      .collect();
+
+    let choices: TokenStream = self
+      .choices
+      .iter()
+      .map(|choice| choice.get_field_implementation(context, prefix))
+      .collect();
+
+    quote!(
+      #elements
+      #choices
+    )
   }
 }
 
@@ -47,10 +60,21 @@ impl Sequence {
     context: &XsdContext,
     prefix: &Option<String>,
   ) -> TokenStream {
-    self
+    let elements: TokenStream = self
       .elements
       .iter()
-      .map(|element| element.get_field_implementation(context, prefix, true, false))
-      .collect()
+      .map(|element| element.get_field_implementation(context, prefix, false, false))
+      .collect();
+
+    let choices: TokenStream = self
+      .choices
+      .iter()
+      .map(|choice| choice.get_field_implementation(context, prefix))
+      .collect();
+
+    quote!(
+      #elements
+      #choices
+    )
   }
 }


### PR DESCRIPTION
Partial support of the [choice](https://www.w3schools.com/xml/el_choice.asp) element. There are quite a number of edge cases I fear. I think best would have been to turn this into an enum, the problem I had is that the id field is optional so I had no idea where to get a name from for the enum. Right now it's not enforced that only a single element can be set. If anyone comes up with a solution for the name I think that would be great, from every perspective I think the enum would be more convenient than multiple optional fields.

What's missing:
- ~~`proper `minOccurs`, `maxOccurs` handling`~~
- documentation generation
- `extension` as a parent
- `restriction` as a parent
- ~~`sequence` as a parent~~
- ... probably more