### PR TITLE
Ignore unrelated attributes

### DIFF
--- a/xml_schema_derive/src/attribute.rs
+++ b/xml_schema_derive/src/attribute.rs
@@ -34,6 +34,10 @@ impl XmlSchemaAttribute {
     let mut target_prefix = None;
 
     for attr in attrs.iter() {
+      if !attr.path.is_ident("xml_schema") {
+        continue;
+      }
+
       let mut attr_iter = attr.clone().tokens.into_iter();
       if let Some(token) = attr_iter.next() {
         if let TokenTree::Group(group) = token {
@@ -114,7 +118,7 @@ mod tests {
   fn generate_attributes(content: &str) -> Vec<Attribute> {
     let mut punctuated = Punctuated::new();
     punctuated.push(PathSegment {
-      ident: Ident::new("yaserde", Span::call_site()),
+      ident: Ident::new("xml_schema", Span::call_site()),
       arguments: PathArguments::None,
     });
 


### PR DESCRIPTION
One might want to use unrelated attributes like `allow` on the struct that need to be ignored by the proc macro to not cause errors.

The use of `yaserde` in the tests seems to be a mistake that worked because the macro happily accepts any attribute it encounters.