### PR TITLE
Handle keywords as field and type names

### DIFF
--- a/xml_schema/Cargo.toml
+++ b/xml_schema/Cargo.toml
@@ -18,5 +18,5 @@ xml-schema-derive = { version = "0.0.7", path = "../xml_schema_derive", optional
 log = "0.4"
 xml-rs = "0.8"
 xml-schema-derive = { version = "0.0.7", path = "../xml_schema_derive" }
-yaserde_derive = { version = "0.4" }
-yaserde = { version = "0.4" }
+yaserde_derive = "0.7"
+yaserde = "0.7"

--- a/xml_schema/tests/complex_type.rs
+++ b/xml_schema/tests/complex_type.rs
@@ -1,12 +1,9 @@
 #[macro_use]
 extern crate yaserde_derive;
 
-use log::debug;
-use std::io::prelude::*;
 use xml_schema_derive::XmlSchema;
 use yaserde::de::from_str;
 use yaserde::ser::to_string;
-use yaserde::{YaDeserialize, YaSerialize};
 
 #[test]
 fn complex_type_string() {

--- a/xml_schema/tests/simple_type.rs
+++ b/xml_schema/tests/simple_type.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate yaserde_derive;
 
-use log::debug;
 use std::io::prelude::*;
 use xml_schema_derive::XmlSchema;
 use yaserde::de::from_str;

--- a/xml_schema_derive/Cargo.toml
+++ b/xml_schema_derive/Cargo.toml
@@ -24,5 +24,5 @@ reqwest = { version = "0.10", features = ["blocking"] }
 simple_logger = "1.6"
 syn = { version = "1.0", features = ["visit", "extra-traits"] }
 xml-rs = "0.8"
-yaserde_derive = { version = "0.4" }
-yaserde = { version = "0.4" }
+yaserde_derive = "0.7"
+yaserde = "0.7"

--- a/xml_schema_derive/src/xsd/annotation.rs
+++ b/xml_schema_derive/src/xsd/annotation.rs
@@ -1,8 +1,6 @@
 use crate::xsd::{attribute::Attribute, Implementation, XsdContext};
 use log::info;
 use proc_macro2::TokenStream;
-use std::io::prelude::*;
-use yaserde::YaDeserialize;
 
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(

--- a/xml_schema_derive/src/xsd/attribute.rs
+++ b/xml_schema_derive/src/xsd/attribute.rs
@@ -2,8 +2,7 @@ use crate::xsd::{
   rust_types_mapping::RustTypesMapping, simple_type::SimpleType, Implementation, XsdContext,
 };
 use heck::SnakeCase;
-use proc_macro2::{Span, TokenStream};
-use syn::Ident;
+use proc_macro2::TokenStream;
 
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(
@@ -55,13 +54,7 @@ impl Implementation for Attribute {
     let raw_name = self.name.clone().unwrap();
     let name = raw_name.to_snake_case();
 
-    let name = if name == "type" {
-      "kind".to_string()
-    } else {
-      name
-    };
-
-    let field_name = Ident::new(&name, Span::call_site());
+    let field_name = format_ident!("r#{}", name);
 
     let rust_type = match (
       self.reference.as_ref(),
@@ -80,11 +73,7 @@ impl Implementation for Attribute {
       quote!(#rust_type)
     };
 
-    let attributes = if name == raw_name {
-      quote!(attribute)
-    } else {
-      quote!(attribute, rename=#raw_name)
-    };
+    let attributes = quote!(attribute, rename=#raw_name);
 
     quote!(
       #[yaserde(#attributes)]

--- a/xml_schema_derive/src/xsd/attribute.rs
+++ b/xml_schema_derive/src/xsd/attribute.rs
@@ -2,11 +2,8 @@ use crate::xsd::{
   rust_types_mapping::RustTypesMapping, simple_type::SimpleType, Implementation, XsdContext,
 };
 use heck::SnakeCase;
-use log::debug;
 use proc_macro2::{Span, TokenStream};
-use std::io::prelude::*;
 use syn::Ident;
-use yaserde::YaDeserialize;
 
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(

--- a/xml_schema_derive/src/xsd/attribute_group.rs
+++ b/xml_schema_derive/src/xsd/attribute_group.rs
@@ -1,6 +1,4 @@
 use crate::xsd::attribute::Attribute;
-use std::io::Read;
-use yaserde::YaDeserialize;
 
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(

--- a/xml_schema_derive/src/xsd/complex_content.rs
+++ b/xml_schema_derive/src/xsd/complex_content.rs
@@ -1,8 +1,5 @@
 use crate::xsd::{extension::Extension, xsd_context::XsdContext};
-use log::debug;
 use proc_macro2::TokenStream;
-use std::io::Read;
-use yaserde::YaDeserialize;
 
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(prefix = "xs", namespace = "xs: http://www.w3.org/2001/XMLSchema")]

--- a/xml_schema_derive/src/xsd/complex_type.rs
+++ b/xml_schema_derive/src/xsd/complex_type.rs
@@ -126,7 +126,7 @@ impl ComplexType {
     }
 
     if self.sequence.is_some() {
-      let list_wrapper = Ident::new(parent_name, Span::call_site());
+      let list_wrapper = format_ident!("r#{}", parent_name);
       return quote!(#list_wrapper);
     }
 

--- a/xml_schema_derive/src/xsd/complex_type.rs
+++ b/xml_schema_derive/src/xsd/complex_type.rs
@@ -3,11 +3,9 @@ use crate::xsd::{
   sequence::Sequence, simple_content::SimpleContent, Implementation, XsdContext,
 };
 use heck::CamelCase;
-use log::{debug, info};
+use log::info;
 use proc_macro2::{Span, TokenStream};
-use std::io::prelude::*;
 use syn::Ident;
-use yaserde::YaDeserialize;
 
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(

--- a/xml_schema_derive/src/xsd/element.rs
+++ b/xml_schema_derive/src/xsd/element.rs
@@ -3,11 +3,9 @@ use crate::xsd::{
   rust_types_mapping::RustTypesMapping, simple_type::SimpleType, Implementation, XsdContext,
 };
 use heck::{CamelCase, SnakeCase};
-use log::{debug, info};
+use log::info;
 use proc_macro2::{Span, TokenStream};
-use std::io::prelude::*;
 use syn::Ident;
-use yaserde::YaDeserialize;
 
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(prefix = "xs", namespace = "xs: http://www.w3.org/2001/XMLSchema")]

--- a/xml_schema_derive/src/xsd/element.rs
+++ b/xml_schema_derive/src/xsd/element.rs
@@ -109,17 +109,13 @@ impl Element {
       return quote!();
     }
 
-    let name = if self.name.to_lowercase() == "type" {
-      "kind".to_string()
-    } else {
-      self.name.to_snake_case()
-    };
+    let name = self.name.to_snake_case();
 
     info!("Generate element {:?}", name);
 
     let name = if multiple { format!("{}s", name) } else { name };
 
-    let attribute_name = Ident::new(&name, Span::call_site());
+    let attribute_name = format_ident!("r#{}", name);
     let yaserde_rename = &self.name;
 
     let rust_type = if let Some(complex_type) = &self.complex_type {

--- a/xml_schema_derive/src/xsd/extension.rs
+++ b/xml_schema_derive/src/xsd/extension.rs
@@ -2,10 +2,7 @@ use crate::xsd::{
   attribute::Attribute, rust_types_mapping::RustTypesMapping, sequence::Sequence, Implementation,
   XsdContext,
 };
-use log::debug;
 use proc_macro2::TokenStream;
-use std::io::prelude::*;
-use yaserde::YaDeserialize;
 
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(

--- a/xml_schema_derive/src/xsd/import.rs
+++ b/xml_schema_derive/src/xsd/import.rs
@@ -1,7 +1,3 @@
-use log::debug;
-use std::io::prelude::*;
-use yaserde::YaDeserialize;
-
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(
   root="schema"

--- a/xml_schema_derive/src/xsd/list.rs
+++ b/xml_schema_derive/src/xsd/list.rs
@@ -1,8 +1,5 @@
 use crate::xsd::{rust_types_mapping::RustTypesMapping, Implementation, XsdContext};
-use log::debug;
 use proc_macro2::{Ident, TokenStream};
-use std::io::prelude::*;
-use yaserde::YaDeserialize;
 
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(prefix = "xs", namespace = "xs: http://www.w3.org/2001/XMLSchema")]

--- a/xml_schema_derive/src/xsd/qualification.rs
+++ b/xml_schema_derive/src/xsd/qualification.rs
@@ -1,7 +1,3 @@
-use log::debug;
-use std::io::prelude::*;
-use yaserde::YaDeserialize;
-
 #[derive(Clone, Debug, PartialEq, YaDeserialize)]
 pub enum Qualification {
   #[yaserde(rename = "qualified")]

--- a/xml_schema_derive/src/xsd/restriction.rs
+++ b/xml_schema_derive/src/xsd/restriction.rs
@@ -1,8 +1,5 @@
 use crate::xsd::{rust_types_mapping::RustTypesMapping, XsdContext};
-use log::debug;
 use proc_macro2::TokenStream;
-use std::io::prelude::*;
-use yaserde::YaDeserialize;
 
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(prefix = "xs", namespace = "xs: http://www.w3.org/2001/XMLSchema")]

--- a/xml_schema_derive/src/xsd/schema.rs
+++ b/xml_schema_derive/src/xsd/schema.rs
@@ -2,10 +2,8 @@ use crate::xsd::{
   attribute, attribute_group, complex_type, element, import, qualification, simple_type,
   Implementation, XsdContext,
 };
-use log::{debug, info};
+use log::info;
 use proc_macro2::TokenStream;
-use std::io::prelude::*;
-use yaserde::YaDeserialize;
 
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(

--- a/xml_schema_derive/src/xsd/sequence.rs
+++ b/xml_schema_derive/src/xsd/sequence.rs
@@ -1,8 +1,6 @@
 use crate::xsd::{element::Element, Implementation, XsdContext};
-use log::{debug, info};
+use log::info;
 use proc_macro2::TokenStream;
-use std::io::prelude::*;
-use yaserde::YaDeserialize;
 
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(prefix = "xs", namespace = "xs: http://www.w3.org/2001/XMLSchema")]

--- a/xml_schema_derive/src/xsd/simple_content.rs
+++ b/xml_schema_derive/src/xsd/simple_content.rs
@@ -1,8 +1,5 @@
 use crate::xsd::{extension::Extension, Implementation, XsdContext};
-use log::debug;
 use proc_macro2::TokenStream;
-use std::io::prelude::*;
-use yaserde::YaDeserialize;
 
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(prefix = "xs", namespace = "xs: http://www.w3.org/2001/XMLSchema")]

--- a/xml_schema_derive/src/xsd/simple_type.rs
+++ b/xml_schema_derive/src/xsd/simple_type.rs
@@ -1,10 +1,7 @@
 use crate::xsd::{list::List, restriction::Restriction, union::Union, Implementation, XsdContext};
 use heck::CamelCase;
-use log::debug;
 use proc_macro2::{Span, TokenStream};
-use std::io::prelude::*;
 use syn::Ident;
-use yaserde::YaDeserialize;
 
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(prefix = "xs", namespace = "xs: http://www.w3.org/2001/XMLSchema")]

--- a/xml_schema_derive/src/xsd/union.rs
+++ b/xml_schema_derive/src/xsd/union.rs
@@ -1,7 +1,3 @@
-use log::debug;
-use std::io::prelude::*;
-use yaserde::YaDeserialize;
-
 #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
 #[yaserde(prefix = "xs", namespace = "xs: http://www.w3.org/2001/XMLSchema")]
 pub struct Union {


### PR DESCRIPTION
Names in the schema that match Rust keywords (in their lowercase version) did not work except for "type" for which some hacks where in place.

We could do the same for struct names but as they are CamelCase (actually rather PascalCase) they should not match keywords anyway.

The yaserde update is necessary to get the fix from https://github.com/media-io/yaserde/pull/93.