### PR TITLE
Update reqwest to 0.11 to address some RustSec advisories

### DIFF
--- a/xml_schema_derive/Cargo.toml
+++ b/xml_schema_derive/Cargo.toml
@@ -23,7 +23,7 @@ heck = "0.3.1"
 log = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"
-reqwest = { version = "0.10", default-features = false, features = ["blocking"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking"] }
 simple_logger = "1.6"
 syn = { version = "1.0", features = ["visit", "extra-traits"] }
 xml-rs = "0.8"


### PR DESCRIPTION
xml-schema-derive currently calls out reqwest="0.10" as a dependency, which indirectly brings in hyper 0.13.10 and tokio 0.2.25. These indirect dependencies have some known security advisories published by RustSec:

 * https://rustsec.org/advisories/RUSTSEC-2021-0078
 * https://rustsec.org/advisories/RUSTSEC-2021-0079
 * https://rustsec.org/advisories/RUSTSEC-2021-0124

I can't vouch for how exploitable these are in practice (I'm personally not using the http feature to fetch a xsd resource), but at the very least we won't be scaring away users with 2+ pages of output from `cargo audit` 😄 