### PR TITLE
Implement quickxml support

### DIFF
--- a/xml_schema/Cargo.toml
+++ b/xml_schema/Cargo.toml
@@ -13,6 +13,8 @@ readme = "../README.md"
 exclude = ["/tests"]
 
 [dependencies]
+quick-xml = { version = "0.31.0", features = ["serialize"] }
+serde = { version = "1.0.193", features = ["serde_derive"] }
 xml-schema-derive = { version = "0.3.0", path = "../xml_schema_derive", optional = true }
 
 [dev-dependencies]

--- a/xml_schema_derive/src/xsd/attribute.rs
+++ b/xml_schema_derive/src/xsd/attribute.rs
@@ -75,14 +75,12 @@ impl Implementation for Attribute {
       quote!(#rust_type)
     };
 
-    let attributes = if name == raw_name {
-      quote!(attribute)
-    } else {
-      quote!(attribute, rename=#raw_name)
-    };
+    let attribute_name = "@".to_string() + &raw_name;
+
+    let attributes = quote!(rename = #attribute_name);
 
     quote!(
-      #[yaserde(#attributes)]
+      #[serde(#attributes)]
       pub #field_name: #rust_type,
     )
   }

--- a/xml_schema_derive/src/xsd/complex_type.rs
+++ b/xml_schema_derive/src/xsd/complex_type.rs
@@ -57,7 +57,7 @@ impl Implementation for ComplexType {
       .map(|complex_content| {
         let complex_content_type = complex_content.get_field_implementation(context, prefix);
         quote!(
-          #[yaserde(flatten)]
+          #[serde(flatten)]
           #complex_content_type,
         )
       })
@@ -84,7 +84,7 @@ impl Implementation for ComplexType {
     quote! {
       #docs
 
-      #[derive(Clone, Debug, Default, PartialEq, yaserde_derive::YaDeserialize, yaserde_derive::YaSerialize)]
+      #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
       #namespace_definition
       pub struct #struct_name {
         #sequence

--- a/xml_schema_derive/src/xsd/element.rs
+++ b/xml_schema_derive/src/xsd/element.rs
@@ -101,7 +101,7 @@ impl Element {
   pub fn get_field_implementation(
     &self,
     context: &XsdContext,
-    prefix: &Option<String>,
+    _prefix: &Option<String>,
   ) -> TokenStream {
     if self.name.is_empty() {
       return quote!();
@@ -148,11 +148,6 @@ impl Element {
       rust_type
     };
 
-    let prefix_attribute = prefix
-      .as_ref()
-      .map(|prefix| quote!(, prefix=#prefix))
-      .unwrap_or_default();
-
     let module = (!context.is_in_sub_module()
       && !self
         .kind
@@ -166,7 +161,7 @@ impl Element {
     .unwrap_or_default();
 
     quote! {
-      #[serde(rename=#rename #prefix_attribute)]
+      #[serde(rename=#rename)]
       pub #attribute_name: #module#rust_type,
     }
   }

--- a/xml_schema_derive/src/xsd/element.rs
+++ b/xml_schema_derive/src/xsd/element.rs
@@ -118,7 +118,11 @@ impl Element {
 
     log::info!("Generate element {:?}", name);
 
-    let name = if multiple { format!("{name}s") } else { name };
+    let name = if multiple {
+      format!("{name}_list")
+    } else {
+      name
+    };
 
     let attribute_name = Ident::new(&name, Span::call_site());
     let rename = &self.name;

--- a/xml_schema_derive/src/xsd/element.rs
+++ b/xml_schema_derive/src/xsd/element.rs
@@ -73,7 +73,7 @@ impl Implementation for Element {
 
     quote! {
       #docs
-      #[derive(Clone, Debug, Default, PartialEq, yaserde_derive::YaDeserialize, yaserde_derive::YaSerialize)]
+      #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
       #namespace_definition
       pub struct #struct_name {
         #fields
@@ -121,7 +121,7 @@ impl Element {
     let name = if multiple { format!("{name}s") } else { name };
 
     let attribute_name = Ident::new(&name, Span::call_site());
-    let yaserde_rename = &self.name;
+    let rename = &self.name;
 
     let rust_type = if let Some(complex_type) = &self.complex_type {
       complex_type.get_integrated_implementation(&self.name)
@@ -166,7 +166,7 @@ impl Element {
     .unwrap_or_default();
 
     quote! {
-      #[yaserde(rename=#yaserde_rename #prefix_attribute)]
+      #[serde(rename=#rename #prefix_attribute)]
       pub #attribute_name: #module#rust_type,
     }
   }
@@ -210,7 +210,7 @@ mod tests {
         {DOCS}
         {DERIVES}
         pub struct Volume {{
-          #[yaserde(flatten)]
+          #[serde(flatten)]
           pub content: xml_schema_types::VolumeType,
         }}"#
     ))

--- a/xml_schema_derive/src/xsd/extension.rs
+++ b/xml_schema_derive/src/xsd/extension.rs
@@ -34,14 +34,8 @@ impl Implementation for Extension {
       .map(|attribute| attribute.implement(namespace_definition, prefix, context))
       .collect();
 
-    let inner_attribute = if format!("{rust_type}") == "String" {
-      quote!(#[yaserde(text)])
-    } else {
-      TokenStream::new()
-    };
-
     quote!(
-      #inner_attribute
+      #[serde(rename="$text")]
       pub content: #rust_type,
       #attributes
     )

--- a/xml_schema_derive/src/xsd/list.rs
+++ b/xml_schema_derive/src/xsd/list.rs
@@ -94,51 +94,6 @@ mod tests {
         pub struct Parent {
           pub items: Vec <String>
         }
-
-        impl yaserde::YaDeserialize for Parent {
-          fn deserialize<R: std::io::Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, String> {
-            loop {
-              match reader.next_event()? {
-                xml::reader::XmlEvent::StartElement{..} => { }
-                xml::reader::XmlEvent::Characters(ref text_content) => {
-                  let items: Vec<String> = text_content.split(' ')
-                    .map(|item| item.to_owned())
-                    .map(|item| item.parse().unwrap())
-                    .collect();
-
-                  return Ok(Parent{items});
-                }
-                _ => { break; }
-              }
-            }
-
-            Err ("Unable to parse attribute" . to_string ())
-          }
-        }
-
-        impl yaserde::YaSerialize for Parent {
-          fn serialize<W: std::io::Write> (&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
-            let content = self
-              .items
-              .iter()
-              .map(|item| item.to_string())
-              .collect:: <Vec<String>>().join(" ");
-
-            let data_event = xml::writer::XmlEvent::characters(&content);
-
-            writer.write(data_event).map_err(|e| e.to_string())? ;
-
-            Ok (())
-          }
-
-          fn serialize_attributes(
-            &self,
-            mut source_attributes: Vec<xml::attribute::OwnedAttribute> ,
-            mut source_namespace: xml::namespace::Namespace
-            ) -> Result<(Vec<xml::attribute::OwnedAttribute> , xml::namespace::Namespace), String> {
-            Ok((source_attributes , source_namespace))
-          }
-        }
       "#).unwrap();
 
     assert_eq!(implementation.to_string(), expected.to_string());

--- a/xml_schema_derive/src/xsd/schema.rs
+++ b/xml_schema_derive/src/xsd/schema.rs
@@ -96,7 +96,7 @@ fn generate_namespace_definition(
     ),
     (Some(prefix), Some(target_namespace)) => {
       let namespace = format!("{prefix}: {target_namespace}");
-      quote!(#[yaserde(prefix=#prefix, namespace=#namespace)])
+      quote!(#[serde(default)])
     }
   }
 }

--- a/xml_schema_derive/src/xsd/simple_type.rs
+++ b/xml_schema_derive/src/xsd/simple_type.rs
@@ -27,12 +27,12 @@ impl Implementation for SimpleType {
     }
 
     quote!(
-      #[derive(Clone, Debug, Default, PartialEq, yaserde_derive::YaDeserialize, yaserde_derive::YaSerialize)]
+      #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
       #namespace_definition
-      pub struct #struct_name {
-        #[yaserde(text)]
-        pub content: std::string::String,
-      }
+      pub struct #struct_name (
+        #[serde(rename="$text")]
+        std::string::String
+      );
     )
   }
 }

--- a/xml_schema_derive/src/xsd/simple_type.rs
+++ b/xml_schema_derive/src/xsd/simple_type.rs
@@ -31,7 +31,7 @@ impl Implementation for SimpleType {
       #namespace_definition
       pub struct #struct_name (
         #[serde(rename="$text")]
-        std::string::String
+        pub std::string::String
       );
     )
   }


### PR DESCRIPTION
Hi,

I'm not sure if quick-xml/serde support is something that you are interested in upstream. Just wanted to open this MR to show some of the early work that I am doing to create serde/quick-xml compatible type definitions. Feel free to close this merge request if it's not a direction that you want to take.

quick-xml of course does not support namespaces so for now I just nerfed the definition and just ignored the parameter. 

One change which is not strictly related is a64a14656dbdfea2e389614bff0bcfb6986da4de. The reason for this is that you can have a lot of nouns with irregular plural like matrix -> matrices, so adding "s" is not the best default to have. I can submit this as a separate MR if it's interesting upstream.

So far I was able to parse XMLs with these descriptions: ttps://sanaregistry.org/files/ndmxml_unqualified/ndmxml-3.0.0-omm-3.0.xsd and ttps://sanaregistry.org/files/ndmxml_unqualified/ndmxml-3.0.0-common-3.0.xsd The parsing has been partial due to some missing things like group, and possible choice so I have to look at that next.