### PR TITLE
 Fix multiple naming

### DIFF
--- a/xml_schema_derive/src/xsd/element.rs
+++ b/xml_schema_derive/src/xsd/element.rs
@@ -118,8 +118,12 @@ impl Element {
 
     log::info!("Generate element {:?}", name);
 
-    let name = if multiple { format!("{name}s") } else { name };
-
+    let name = if multiple {
+      format!("{name}_list")
+    } else {
+      name
+    };
+    
     let attribute_name = Ident::new(&name, Span::call_site());
     let yaserde_rename = &self.name;
 


### PR DESCRIPTION
Using plural can go wrong when the field name has an irregular plural,
like the word "matrix" with plural "matrices".