### PR TITLE
Changed serde to yaserde

### DIFF
--- a/xml_schema_derive/src/xsd/group.rs
+++ b/xml_schema_derive/src/xsd/group.rs
@@ -37,7 +37,7 @@ impl Implementation for Group {
       .unwrap_or_default();
 
     quote!(
-      #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+      #[derive(Clone, Debug, Default, PartialEq, yaserde_derive::YaDeserialize, yaserde_derive::YaSerialize)]
       #namespace_definition
       pub struct #struct_name {
         #fields


### PR DESCRIPTION
There's a reference to serde in the ``TokenStream`` for groups, while yaserde is used everywhere else.