### PR TITLE
Added sequences to extension generation

### DIFF
--- a/xml_schema_derive/src/xsd/complex_type.rs
+++ b/xml_schema_derive/src/xsd/complex_type.rs
@@ -58,7 +58,7 @@ impl Implementation for ComplexType {
         let complex_content_type = complex_content.get_field_implementation(context, prefix);
         quote!(
           #[yaserde(flatten)]
-          #complex_content_type,
+          #complex_content_type
         )
       })
       .unwrap_or_default();


### PR DESCRIPTION
This adds new fields to the struct, if it is an extended type.
Previously only attribute were added, but not sequence elements.

The following example schema
```xml
<xs:complexType name="fullpersoninfo">
  <xs:complexContent>
    <xs:extension base="personinfo">
      <xs:sequence>
        <xs:element name="address" type="xs:string"/>
        <xs:element name="city" type="xs:string"/>
        <xs:element name="country" type="xs:string"/>
      </xs:sequence>
    </xs:extension>
  </xs:complexContent>
</xs:complexType>
```
will result in the following code
```rust
# [derive (Clone , Debug , Default , PartialEq , yaserde_derive :: YaDeserialize , yaserde_derive :: YaSerialize)]
pub struct Fullpersoninfo {
  # [yaserde (flatten)]
  pub base : Personinfo ,
  # [yaserde (rename = \"address\")]
  pub address : String ,
  # [yaserde (rename = \"city\")]
  pub city : String ,
  # [yaserde (rename = \"country\")]
  pub country : String ,
}
```